### PR TITLE
Added GitHub build-badge and dispatch_workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   #---LINUX BUILD JOB(S)---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An example of using Conan to link against OpenCV and some other 3rd party librar
 
 # Build Status
 
-[![Build Status](https://travis-ci.org/JarnoRalli/conan-example.svg?branch=master)](https://travis-ci.org/JarnoRalli/conan-example)
+[![Build and Test](https://github.com/JarnoRalli/conan-example/actions/workflows/build.yml/badge.svg)](https://github.com/JarnoRalli/conan-example/actions/workflows/build.yml)
 
 ## Conan Generators
 This example tests three different Conan generators:


### PR DESCRIPTION
This PR adds:

- GitHub build-badge to the top level README.md
- workflow_dispatch in order to be able to manually run workflows